### PR TITLE
fix(lifecycle): thread owns all lifecycle events, agent is event bus

### DIFF
--- a/packages/kernl/src/kernl/kernl.ts
+++ b/packages/kernl/src/kernl/kernl.ts
@@ -102,42 +102,8 @@ export class Kernl extends KernlHooks {
     thread: Thread<TContext, TOutput>,
   ): Promise<ThreadExecuteResult<ResolvedAgentResponse<TOutput>>> {
     this.athreads.set(thread.tid, thread);
-
-    this.emit("thread.start", {
-      kind: "thread.start",
-      threadId: thread.tid,
-      agentId: thread.agent.id,
-      namespace: thread.namespace,
-      context: thread.context,
-    });
-
     try {
-      const result = await thread.execute();
-
-      this.emit("thread.stop", {
-        kind: "thread.stop",
-        threadId: thread.tid,
-        agentId: thread.agent.id,
-        namespace: thread.namespace,
-        context: thread.context,
-        state: thread.state,
-        outcome: "success",
-        result: result.response,
-      });
-
-      return result;
-    } catch (err) {
-      this.emit("thread.stop", {
-        kind: "thread.stop",
-        threadId: thread.tid,
-        agentId: thread.agent.id,
-        namespace: thread.namespace,
-        context: thread.context,
-        state: thread.state,
-        outcome: "error",
-        error: err instanceof Error ? err.message : String(err),
-      });
-      throw err;
+      return await thread.execute();
     } finally {
       this.athreads.delete(thread.tid);
     }
@@ -168,39 +134,8 @@ export class Kernl extends KernlHooks {
     thread: Thread<TContext, TOutput>,
   ): AsyncIterable<ThreadStreamEvent> {
     this.athreads.set(thread.tid, thread);
-
-    this.emit("thread.start", {
-      kind: "thread.start",
-      threadId: thread.tid,
-      agentId: thread.agent.id,
-      namespace: thread.namespace,
-      context: thread.context,
-    });
-
     try {
       yield* thread.stream();
-
-      this.emit("thread.stop", {
-        kind: "thread.stop",
-        threadId: thread.tid,
-        agentId: thread.agent.id,
-        namespace: thread.namespace,
-        context: thread.context,
-        state: thread.state,
-        outcome: "success",
-      });
-    } catch (err) {
-      this.emit("thread.stop", {
-        kind: "thread.stop",
-        threadId: thread.tid,
-        agentId: thread.agent.id,
-        namespace: thread.namespace,
-        context: thread.context,
-        state: thread.state,
-        outcome: "error",
-        error: err instanceof Error ? err.message : String(err),
-      });
-      throw err;
     } finally {
       this.athreads.delete(thread.tid);
     }

--- a/packages/kernl/src/lifecycle.ts
+++ b/packages/kernl/src/lifecycle.ts
@@ -74,17 +74,12 @@ export interface ThreadStopEvent<TContext = unknown, TOutput = unknown> {
   state: ThreadState;
 
   /**
-   * The outcome of the execution.
-   */
-  outcome: "success" | "error" | "cancelled";
-
-  /**
-   * The result if outcome is "success".
+   * The result of execution (present on success).
    */
   result?: TOutput;
 
   /**
-   * Error message if outcome is "error".
+   * Error message (present on error).
    */
   error?: string;
 }

--- a/packages/kernl/src/thread/utils.ts
+++ b/packages/kernl/src/thread/utils.ts
@@ -113,11 +113,10 @@ export function isPublicEvent(event: ThreadEvent): event is PublicThreadEvent {
  * Returns null if no assistant message with text content is found.
  */
 export function getFinalResponse(items: LanguageModelItem[]): string | null {
-  // Scan backwards for the last assistant message
+  // scan backwards for the last assistant message
   for (let i = items.length - 1; i >= 0; i--) {
     const item = items[i];
     if (item.kind === "message" && item.role === "assistant") {
-      // Extract text from content parts
       for (const part of item.content) {
         if (part.kind === "text") {
           return part.text;
@@ -161,6 +160,6 @@ export function parseFinalResponse<TOutput extends AgentOutputType>(
     }
   }
 
-  // Fallback - should not reach here
+  // fallback - should not reach here
   return text as ResolvedAgentResponse<TOutput>;
 }


### PR DESCRIPTION
## Summary

- Move thread.start/stop emissions from Kernl to Thread.stream()
- Simplify Kernl.spawn/schedule to just scheduler responsibilities  
- Add `tickres` field to store final result for thread.stop event
- Remove `outcome` field from ThreadStopEvent (redundant with result/error)
- Both `agent.on()` and `kernl.on()` now receive all lifecycle events

## Problem

- `schedule()` and `scheduleStream()` were missing thread.start/stop events
- `agent.on("thread.*")` never fired because Thread was emitting via kernl instead of agent

## Architecture

Thread is now the canonical owner of execution lifecycle:
- Thread emits all events via `agent.emit()`
- Agent listeners receive events directly
- Kernl listeners receive events via propagation from agent
- Kernl is now just a scheduler (manages athreads map)

## Test plan

- [x] All 222 tests pass
- [x] Verified in playground with watson agent
- [x] Both `kernl.on()` and `agent.on()` receive identical events